### PR TITLE
Updated scala toolchain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 
 ## [unreleased]
+- Drop support scala-2.12 for Scala.JS and Scala-Native
+- Switched to scala-2.12.19
+- Switched to scala-2.13.13
+- Switched to scala-3.4.0
+- Switched to scalajs-1.15.0
+- Switched to scala-native-0.4.7
 
 ## [1.0.1] - 2022-05-10
 - Switched to scala-3.1.2

--- a/build.sbt
+++ b/build.sbt
@@ -2,9 +2,9 @@ import sbtcrossproject.CrossPlugin.autoImport.crossProject
 
 lazy val scala210 = "2.10.7"
 lazy val scala211 = "2.11.12"
-lazy val scala212 = "2.12.17"
-lazy val scala213 = "2.13.10"
-lazy val scala31 = "3.2.0"
+lazy val scala212 = "2.12.19"
+lazy val scala213 = "2.13.13"
+lazy val scala3 = "3.4.0"
 
 lazy val scalatestVersion = "3.2.18"
 lazy val jmhVersion = "1.37"
@@ -13,7 +13,7 @@ name := "biginteger"
 ThisBuild / organization := "pt.kcry"
 ThisBuild / dynverSeparator := "-"
 
-ThisBuild / scalaVersion := scala31
+ThisBuild / scalaVersion := scala3
 ThisBuild / crossScalaVersions := Seq()
 
 ThisBuild / scalacOptions ++= Seq(
@@ -47,14 +47,14 @@ lazy val biginteger = crossProject(JSPlatform, JVMPlatform, NativePlatform)
     headerLicense := LicenseDefinition.template
   )
   .jvmSettings(
-    crossScalaVersions := Seq(scala210, scala212, scala211, scala213, scala31)
+    crossScalaVersions := Seq(scala210, scala212, scala211, scala213, scala3)
   )
   .jsSettings(
-    crossScalaVersions := Seq(scala211, scala212, scala213, scala31),
+    crossScalaVersions := Seq(scala212, scala213, scala3),
     Test / scalaJSStage := FullOptStage
   )
   .nativeSettings(
-    crossScalaVersions := Seq(scala211, scala212, scala213, scala31),
+    crossScalaVersions := Seq(scala212, scala213, scala3),
     Test / nativeMode:= "release-fast",
     Test / nativeLinkStubs := true
   )

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,8 +1,8 @@
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject"      % "1.3.2")
 addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "1.3.2")
 
-addSbtPlugin("org.scala-js"       % "sbt-scalajs"                   % "1.11.0")
-addSbtPlugin("org.scala-native"   % "sbt-scala-native"              % "0.4.7")
+addSbtPlugin("org.scala-js"       % "sbt-scalajs"                   % "1.15.0")
+addSbtPlugin("org.scala-native"   % "sbt-scala-native"              % "0.4.17")
 
 addSbtPlugin("pl.project13.scala" % "sbt-jmh"                       % "0.4.7")
 addSbtPlugin("com.eed3si9n"       % "sbt-assembly"                  % "2.1.5")


### PR DESCRIPTION
All this changes simple to delivery in one step.

Thus, modern Scala.JS and Scala-Native drop support of scala-2.11 that forces me to do the same.